### PR TITLE
Support Icarus Verilog for simulation with open source tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ icestick.bin
 icestick.blif
 icestick.json
 icestick.rpt
+test_top.vcd
+test_top.vvp

--- a/chapter10/board/yosys-icestick/Makefile
+++ b/chapter10/board/yosys-icestick/Makefile
@@ -4,6 +4,7 @@ SRCS += $(SRCDIR)/prescaler.sv
 SRCS += $(SRCDIR)/mother_board.sv
 SRCS += $(SRCDIR)/mother_board/cpu.sv
 SRCS += $(SRCDIR)/mother_board/rom.sv
+TSRCS = ./test_top.sv
 
 
 PROJ = icestick
@@ -32,6 +33,15 @@ all: $(PROJ).rpt $(PROJ).bin
 %.rpt: %.asc
 	icetime -d $(DEVICE) -mtr $@ $<
 
+test_top.vvp: $(TSRCS) $(SRCS)
+	iverilog -g2012 -o $@ $^
+
+test_top.vcd: test_top.vvp
+	vvp -N $< +vcd
+
+sim: test_top.vcd
+	gtkwave test_top.vcd
+
 prog: $(PROJ).bin
 	iceprog $<
 
@@ -40,7 +50,7 @@ sudo-prog: $(PROJ).bin
 	sudo iceprog $<
 
 clean:
-	rm -f $(PROJ).blif $(PROJ).json $(PROJ).asc $(PROJ).rpt $(PROJ).bin
+	rm -f $(PROJ).blif $(PROJ).json $(PROJ).asc $(PROJ).rpt $(PROJ).bin test_top.vvp test_top.vcd
 
 .SECONDARY:
 .PHONY: all prog clean

--- a/chapter10/board/yosys-icestick/README.txt
+++ b/chapter10/board/yosys-icestick/README.txt
@@ -9,9 +9,23 @@
 
 ## 2. ツールのインストール
 
-コンソールから下記のコマンドを実行して、合成に必要なツールをインストールしてください。
+コンソールから下記のコマンドを実行して、シミュレーションと合成に必要なツールをインストールしてください。
 
 ```
+$ git clone https://github.com/gtkwave/gtkwave.git
+$ cd gtkwave/gtkwave3
+$ sh autogen.sh
+$ ./configure
+$ make -j4
+$ sudo make install
+
+$ git clone https://github.com/steveicarus/iverilog.git
+$ cd iverilog
+$ sh autoconf.sh
+$ ./configure
+$ make -j4
+$ sudo make install
+
 $ git clone https://github.com/YosysHQ/icestorm.git icestorm
 $ cd icestorm
 $ make -j4
@@ -31,10 +45,29 @@ $ sudo make install
 
 ツールのインストール方法について詳しくは以下のページを参照してください。
 
+* GTKWave
+  http://gtkwave.sourceforge.net/
+* Installation Guide | Icarus Verilog | Fandom
+  https://iverilog.fandom.com/wiki/Installation_Guide
 * Project IceStorm
   http://www.clifford.at/icestorm/
 
-## 3. 論理合成と配置配線
+## 3. シミュレーション
+
+本ディレクトリで下記のコマンドを実行してください。
+するとシミュレーションを実行した後、GTKWaveが起動します。
+
+```
+$ cd cpubook-code/chapter10/board/yosys-icestick
+$ make sim
+```
+
+GTKWaveウィンドウの"SST"という枠にある"test_top"を右クリックしてください。
+"Recurse Import"を選択し、さらに"Insert"をクリックします。
+"Really import 29 facilits?"とのウィンドウが出るので"Yes"ボタンをクリックします。
+Ctrlキーと0キーを同時に押すとシミュレーション波形全体を表示します。
+
+## 4. 論理合成と配置配線
 
 本ディレクトリで下記のコマンドを実行して論理合成と配置配線をしてください。
 
@@ -43,7 +76,7 @@ $ cd cpubook-code/chapter10/board/yosys-icestick
 $ make
 ```
 
-## 4. コンフィグレーションと実行
+## 5. コンフィグレーションと実行
 
 iCEstick Evaluation Kitを開発環境のUSBポートに接続してください。
 

--- a/chapter10/board/yosys-icestick/test_top.sv
+++ b/chapter10/board/yosys-icestick/test_top.sv
@@ -1,0 +1,30 @@
+`timescale 1ns/1ps
+module test_top();
+  logic pin_clock, pin_n_reset, pin_led;
+  top top(.*);
+
+  always #5 pin_clock = ~pin_clock;
+  initial   pin_clock = 1'b0;
+
+  defparam top.prescaler.RATIO      = 2;
+  initial  top.prescaler.counter    = 32'd0;
+  initial  top.prescaler.slow_clock = 1'b0;
+
+  initial begin
+    if ($test$plusargs("vcd")) begin
+      $dumpfile("test_top.vcd");
+      $dumpvars(0, test_top);
+    end
+  end
+
+  initial begin
+    pin_n_reset = 1'b0;
+    #10;
+    pin_n_reset = 1'b1;
+  end
+
+  initial begin
+    #200;
+    $finish();
+  end
+endmodule

--- a/chapter12/board/yosys-icestick/Makefile
+++ b/chapter12/board/yosys-icestick/Makefile
@@ -4,6 +4,7 @@ SRCS += $(SRCDIR)/prescaler.sv
 SRCS += $(SRCDIR)/mother_board.sv
 SRCS += $(SRCDIR)/mother_board/cpu.sv
 SRCS += $(SRCDIR)/mother_board/rom.sv
+TSRCS = ./test_top.sv
 
 
 PROJ = icestick
@@ -32,6 +33,15 @@ all: $(PROJ).rpt $(PROJ).bin
 %.rpt: %.asc
 	icetime -d $(DEVICE) -mtr $@ $<
 
+test_top.vvp: $(TSRCS) $(SRCS)
+	iverilog -g2012 -o $@ $^
+
+test_top.vcd: test_top.vvp
+	vvp -N $< +vcd
+
+sim: test_top.vcd
+	gtkwave test_top.vcd
+
 prog: $(PROJ).bin
 	iceprog $<
 
@@ -40,7 +50,7 @@ sudo-prog: $(PROJ).bin
 	sudo iceprog $<
 
 clean:
-	rm -f $(PROJ).blif $(PROJ).json $(PROJ).asc $(PROJ).rpt $(PROJ).bin
+	rm -f $(PROJ).blif $(PROJ).json $(PROJ).asc $(PROJ).rpt $(PROJ).bin test_top.vvp test_top.vcd
 
 .SECONDARY:
 .PHONY: all prog clean

--- a/chapter12/board/yosys-icestick/README.txt
+++ b/chapter12/board/yosys-icestick/README.txt
@@ -9,9 +9,23 @@
 
 ## 2. ツールのインストール
 
-コンソールから下記のコマンドを実行して、合成に必要なツールをインストールしてください。
+コンソールから下記のコマンドを実行して、シミュレーションと合成に必要なツールをインストールしてください。
 
 ```
+$ git clone https://github.com/gtkwave/gtkwave.git
+$ cd gtkwave/gtkwave3
+$ sh autogen.sh
+$ ./configure
+$ make -j4
+$ sudo make install
+
+$ git clone https://github.com/steveicarus/iverilog.git
+$ cd iverilog
+$ sh autoconf.sh
+$ ./configure
+$ make -j4
+$ sudo make install
+
 $ git clone https://github.com/YosysHQ/icestorm.git icestorm
 $ cd icestorm
 $ make -j4
@@ -31,10 +45,29 @@ $ sudo make install
 
 ツールのインストール方法について詳しくは以下のページを参照してください。
 
+* GTKWave
+  http://gtkwave.sourceforge.net/
+* Installation Guide | Icarus Verilog | Fandom
+  https://iverilog.fandom.com/wiki/Installation_Guide
 * Project IceStorm
   http://www.clifford.at/icestorm/
 
-## 3. 論理合成と配置配線
+## 3. シミュレーション
+
+本ディレクトリで下記のコマンドを実行してください。
+するとシミュレーションを実行した後、GTKWaveが起動します。
+
+```
+$ cd cpubook-code/chapter12/board/yosys-icestick
+$ make sim
+```
+
+GTKWaveウィンドウの"SST"という枠にある"test_top"を右クリックしてください。
+"Recurse Import"を選択し、さらに"Insert"をクリックします。
+"Really import 41 facilits?"とのウィンドウが出るので"Yes"ボタンをクリックします。
+Ctrlキーと0キーを同時に押すとシミュレーション波形全体を表示します。
+
+## 4. 論理合成と配置配線
 
 元のprescalerのままだとiCEstick Evaluation Kitにとっては遅いので、以下のファイルを編集して分周比を変更してください。
 
@@ -64,7 +97,7 @@ $ cd cpubook-code/chapter12/board/yosys-icestick
 $ make
 ```
 
-## 4. コンフィグレーションと実行
+## 5. コンフィグレーションと実行
 
 iCEstick Evaluation Kitを開発環境のUSBポートに接続してください。
 
@@ -80,3 +113,4 @@ iCEstick Evaluation Kit上のLEDにBレジスタの内容が表示され、最�
 ## A. 制限
 
 * iCEstick Evaluation KitにはスイッチがないのでIN命令はディジタルI/Oから定値を読み出します
+* Icarus VerilogとYosysはuniqueをサポートしておらず、単に無視します

--- a/chapter12/board/yosys-icestick/test_top.sv
+++ b/chapter12/board/yosys-icestick/test_top.sv
@@ -1,0 +1,35 @@
+`timescale 1ns/1ps
+module test_top();
+  logic       pin_clock;
+  logic       pin_n_reset;
+  logic [3:0] pin_switch;
+  logic [3:0] pin_led;
+  top top(.*);
+
+  always #5 pin_clock = ~pin_clock;
+  initial   pin_clock = 1'b0;
+
+  defparam top.prescaler.RATIO      = 2;
+  initial  top.prescaler.counter    = 32'd0;
+  initial  top.prescaler.slow_clock = 1'b0;
+
+  initial begin
+    if ($test$plusargs("vcd")) begin
+      $dumpfile("test_top.vcd");
+      $dumpvars(0, test_top);
+    end
+  end
+
+  initial begin
+    pin_n_reset = 1'b0;
+    #10;
+    pin_n_reset = 1'b1;
+  end
+
+  initial pin_switch = 4'd6;
+
+  initial begin
+    #2000;
+    $finish();
+  end
+endmodule


### PR DESCRIPTION
> この修正には残念ながら以下の制約があります:
>
> * iverilogがSystem Verilogをサポートしていないので、シュミレーションが行なえない

と前回のPRでレポートしたのですが、その後調査の結果Icarus Verilogに-g2012を渡すとalways_ffとalways_combのシミュレーションが可能であることがわかりました。

そこでTD4をIcarus Verilogでシミュレーションできるようにしてみました。
もし受け入れ可能であればmergeしていただけると嬉しいです。

より詳細な説明をブログにまとめました:
https://kiwamu.wordpress.com/2020/12/30/icarus-verilog%e3%81%af%e6%97%a2%e3%81%abalways_ff%e3%81%a8always_comb%e3%82%92%e3%82%b5%e3%83%9d%e3%83%bc%e3%83%88%e3%81%97%e3%81%a6%e3%81%84%e3%81%9f%e8%a9%b1/